### PR TITLE
Fixed wildcard pattern in sonar-7.properties

### DIFF
--- a/provisioning/files/sonar/sonar-7.properties
+++ b/provisioning/files/sonar/sonar-7.properties
@@ -37,5 +37,5 @@ sonar.phpCodesniffer.timeout=240
 # Files to exclude
 sonar.exclusions=**/*.features.*,\
     **/*.field_group.inc,\
-    ***/*.strongarm.inc,\
+    **/*.strongarm.inc,\
     **/*.views_default.inc


### PR DESCRIPTION
According to Sonarqube's documentation on [wildcard pattern](https://docs.sonarqube.org/display/SONAR/Narrowing+the+Focus#NarrowingtheFocus-Patterns), we can only use `*`, `**` and `?`.

While this may work depending on how Sonarqube's regex is implemented, I propose to change `***` to `**` for correctness.